### PR TITLE
Make it easier to inject your own Markdown renderer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,16 +63,32 @@ back with two attributes: output and metadata.
     data.output #=> "<p>hello, world</p>\n"
     data.metadata #=> {"key" => "value"}
 
-If you don't want to use Markdown, I assume you're using a Tilt
-template of some kind:
+The default Markdown parser Metadown uses is pretty simple. If you'd
+like to change it, you can inject your own in the standard Redcarpet 
+fashion. Here's an example with code highlighting using Pygments.
 
-    require 'metadown'
-    require 'erb'
-    require 'tilt'
-    
-    data = Metadown.render("<h1><%= 'Hi' %></h1>", Tilt::ERBTemplate)
-    data.output #=> "<h1>Hi</h1>"
-    data.metadata #=> "{}"
+```ruby
+class HTMLwithPygments < Metadown::Renderer
+  def block_code(code, language)
+    Pygments.highlight(code, :lexer => language)
+  end
+end
+```
+
+Then use it with Metadown like this:
+
+```ruby
+require 'metadown'
+require 'html_with_pygments'
+
+renderer = Redcarpet::Markdown.new(HTMLwithPygments, :fenced_code_blocks => true)
+data = Metadown.render("```ruby\nself\n```", renderer)
+data.output   #=> "<div class=\"highlight\"><pre><span class=\"nb\">self</span>\n</pre>\n</div>\n"
+data.metadata #=> "{}"
+```
+
+The Redcarpet [README](https://github.com/vmg/redcarpet/blob/master/README.markdown)
+has more examples on how to customize your Markdown rendering.
     
 ## Contributing
 

--- a/lib/metadown.rb
+++ b/lib/metadown.rb
@@ -7,7 +7,7 @@ require "metadown/version"
 module Metadown
 
   # This struct is what gets returned from a call to #render.
-  # 
+  #
   # It has two attributes, one for the metadata, and one for the rendered
   # output.
   Data = Struct.new(:metadata, :output)
@@ -20,7 +20,7 @@ module Metadown
 
     metadata = MetadataParser.new(text).parse
 
-    Data.new(metadata, renderer.new { text }.render)
+    Data.new(metadata, renderer.render(text))
   end
   module_function :render
 

--- a/spec/metadown_spec.rb
+++ b/spec/metadown_spec.rb
@@ -20,12 +20,12 @@ MARKDOWN
   end
 
   it "allows you to inject a parser" do
-    parser = stub(:new => stub(:render => "wat"))
+    parser = double :render => "<p>hello world</p>"
 
     Metadown.render(text, parser).tap do |data|
       data.should be_kind_of(Metadown::Data)
       data.metadata.should eql({"key" => "value"})
-      data.output.should eql("wat")
+      data.output.should eql("<p>hello world</p>")
     end
   end
 end


### PR DESCRIPTION
Basically just adjusts the interface Metadown uses for different renderers to be compatible with Redcarpet. Makes it much easier to customize Markdown rendering and kinda "fixes" issue #1.

Please review.
